### PR TITLE
Add optional salary field to job prospects and display it on cards

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -36,6 +36,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       jobUrl: "",
       status: "Bookmarked",
       interestLevel: "Medium",
+      salary: undefined,
       notes: "",
     },
   });
@@ -156,6 +157,30 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  placeholder="e.g. 120000"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    field.onChange(val === "" ? undefined : parseInt(val, 10));
+                  }}
+                  data-testid="input-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -41,6 +41,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       jobUrl: prospect.jobUrl ?? "",
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
+      salary: prospect.salary ?? undefined,
       notes: prospect.notes ?? "",
     },
   });
@@ -160,6 +161,30 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Salary (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  placeholder="e.g. 120000"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    field.onChange(val === "" ? null : parseInt(val, 10));
+                  }}
+                  data-testid="input-edit-salary"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -105,6 +105,12 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          {prospect.salary != null && (
+            <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400" data-testid={`text-salary-${prospect.id}`}>
+              <DollarSign className="w-3 h-3" />
+              {prospect.salary.toLocaleString("en-US")}
+            </span>
+          )}
         </div>
 
         {prospect.jobUrl && (

--- a/replit.md
+++ b/replit.md
@@ -30,10 +30,11 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, salary, notes, created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low
+- **Salary**: Optional integer field, displayed as formatted currency (e.g. "$120,000")
 
 ## API
 

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -21,3 +21,81 @@ describe("prospect creation validation", () => {
     expect(result.errors).toContain("Role title is required");
   });
 });
+
+describe("salary field validation", () => {
+  test("accepts a valid salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 120000,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts when salary is omitted", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts when salary is null", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects a negative salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: -50000,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive number");
+  });
+
+  test("rejects zero as salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 0,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a positive number");
+  });
+
+  test("rejects a non-integer salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 120000.50,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a whole number");
+  });
+
+  test("rejects a string salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: "120000" as unknown,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a whole number");
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,14 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.salary !== undefined && data.salary !== null) {
+    if (typeof data.salary !== "number" || !Number.isInteger(data.salary)) {
+      errors.push("Salary must be a whole number");
+    } else if (data.salary <= 0) {
+      errors.push("Salary must be a positive number");
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -33,27 +33,23 @@ export async function registerRoutes(
     }
 
     const body = req.body;
+
+    const partialSchema = insertProspectSchema.partial();
+    const parsed = partialSchema.safeParse(body);
+    if (!parsed.success) {
+      return res.status(400).json({ message: parsed.error.errors.map((e) => e.message).join(", ") });
+    }
+
+    const validated = parsed.data;
     const updates: Record<string, unknown> = {};
 
-    if (body.companyName !== undefined) updates.companyName = body.companyName;
-    if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
-    if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
-    if (body.notes !== undefined) updates.notes = body.notes;
-
-    if (body.status !== undefined) {
-      if (!STATUSES.includes(body.status)) {
-        return res.status(400).json({ message: `Status must be one of: ${STATUSES.join(", ")}` });
-      }
-      updates.status = body.status;
-    }
-
-    if (body.interestLevel !== undefined || body.interest_level !== undefined) {
-      const level = body.interestLevel ?? body.interest_level;
-      if (!INTEREST_LEVELS.includes(level)) {
-        return res.status(400).json({ message: `Interest level must be one of: ${INTEREST_LEVELS.join(", ")}` });
-      }
-      updates.interestLevel = level;
-    }
+    if (validated.companyName !== undefined) updates.companyName = validated.companyName;
+    if (validated.roleTitle !== undefined) updates.roleTitle = validated.roleTitle;
+    if (validated.jobUrl !== undefined) updates.jobUrl = validated.jobUrl;
+    if ("salary" in body) updates.salary = validated.salary ?? null;
+    if (validated.notes !== undefined) updates.notes = validated.notes;
+    if (validated.status !== undefined) updates.status = validated.status;
+    if (validated.interestLevel !== undefined) updates.interestLevel = validated.interestLevel;
 
     const updated = await storage.updateProspect(id, updates);
     res.json(updated);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -21,6 +21,7 @@ export const prospects = pgTable("prospects", {
   jobUrl: text("job_url"),
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
+  salary: integer("salary"),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -34,6 +35,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   status: z.enum(STATUSES).default("Bookmarked"),
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
+  salary: z.number().int().positive("Salary must be a positive number").optional().nullable(),
   notes: z.string().optional().nullable(),
 });
 


### PR DESCRIPTION
Adds an optional integer 'salary' field to the prospects table, updates forms to include and validate this field, displays formatted salary on prospect cards, and enhances server-side validation with Zod.
